### PR TITLE
remove artifact of period being in seconds instead of minutes

### DIFF
--- a/check_dynamodb_capacity.py
+++ b/check_dynamodb_capacity.py
@@ -91,9 +91,6 @@ def main():
     if args.capacity not in CAPACITY_METRIC.keys():
         argp.error('Capacity not valid')
 
-    if args.period < 60 or args.period % 60 != 0:
-        argp.error('Period must be at least 60 seconds and multiple of 60.')
-
     if args.capacity in ['read_index', 'write_index']:
         if not args.index:
             argp.error('If capacity is read_index or write_index, an index'


### PR DESCRIPTION
Hey there,

I noticed that this check was in place, and seemed to be assuming that the `--period` argument represented seconds and not minutes. It blocked me from being able to use this script for looking back over periods of less than an hour.

Great script! Thanks for open sourcing!